### PR TITLE
Added repository name to maven id

### DIFF
--- a/reposilite-frontend/src/store/maven/repository.js
+++ b/reposilite-frontend/src/store/maven/repository.js
@@ -22,6 +22,7 @@ export default function useRepository() {
 
   const createRepositories = (qualifier) => {
     const repository = computed(() => qualifier.path.split('/')[0])
+    const repoId = id + (qualifier.path ? `-${repository.value}` : '')
     const domain = location.protocol + '//' + location.host + (qualifier.path ? `/${repository.value}` : '/{repository}')
 
     return [
@@ -30,7 +31,7 @@ export default function useRepository() {
         lang: 'xml',
           snippet: `
 <repository>
-  <id>${id}</id>
+  <id>${repoId}</id>
   <name>${title}</name>
   <url>${domain}</url>
 </repository>
@@ -49,7 +50,7 @@ export default function useRepository() {
     {
       name: 'SBT',
         lang: 'scala',
-          snippet: `resolvers += "${id}" at "${domain}"`
+          snippet: `resolvers += "${repoId}" at "${domain}"`
     }
     ]
   }


### PR DESCRIPTION
Added this to my personal build, but thought it could be a good addition for the main release. 

When on the overview and selecting a respository, e.g. snapshots, it basically just adds "-snapshot" behind the repository id.

![image](https://user-images.githubusercontent.com/17951467/134184659-46b0f323-47b3-425f-804c-21c13df940ee.png)
